### PR TITLE
Remove js

### DIFF
--- a/lib/mongoid/locker.rb
+++ b/lib/mongoid/locker.rb
@@ -139,7 +139,11 @@ module Mongoid
           '$and': [
             { locking_name_field => { '$exists': true, '$ne': nil } },
             { locked_at_field => { '$exists': true, '$ne': nil } },
-            { '$where': "new Date() - this.#{locked_at_field} < #{lock_timeout * 1000}" }
+            { 
+              # Compare locked_at to current date in seconds plus lockout time
+              model.locked_at_field => { '$lt': DateTime.now.to_i + model.lock_timeout }
+              # Replaces JS: '$where': "new Date() - this.#{locked_at_field} < #{lock_timeout * 1000}"  
+            }
           ]
         )
       end
@@ -169,7 +173,9 @@ module Mongoid
               ]
             },
             {
-              '$where': "new Date() - this.#{locked_at_field} >= #{lock_timeout * 1000}"
+              # Compare locked_at to current date in seconds plus lockout time
+              model.locked_at_field => { '$gte': DateTime.now.to_i + model.lock_timeout }
+              # Replaces JS: '$where': "new Date() - this.#{locked_at_field} >= #{lock_timeout * 1000}"
             }
           ]
         )

--- a/lib/mongoid/locker.rb
+++ b/lib/mongoid/locker.rb
@@ -139,10 +139,11 @@ module Mongoid
           '$and': [
             { locking_name_field => { '$exists': true, '$ne': nil } },
             { locked_at_field => { '$exists': true, '$ne': nil } },
-            { 
+            {
               # Compare locked_at to current date in seconds plus lockout time
-              model.locked_at_field => { '$lt': DateTime.now.to_i - model.lock_timeout }
-              # Replaces JS: '$where': "new Date() - this.#{locked_at_field} < #{lock_timeout * 1000}"  
+              locked_at_field => { '$gte': Time.now - lock_timeout.seconds }
+              # Replaces JS:
+              # '$where': "new Date() - this.#{locked_at_field} < #{lock_timeout * 1000}"
             }
           ]
         )
@@ -174,8 +175,9 @@ module Mongoid
             },
             {
               # Compare locked_at to current date in seconds plus lockout time
-              model.locked_at_field => { '$gte': DateTime.now.to_i - model.lock_timeout }
-              # Replaces JS: '$where': "new Date() - this.#{locked_at_field} >= #{lock_timeout * 1000}"
+              locked_at_field => { '$lt': Time.now - lock_timeout.seconds }
+              # Replaces JS:
+              # '$where': "new Date() - this.#{locked_at_field} >= #{lock_timeout * 1000}"
             }
           ]
         )

--- a/lib/mongoid/locker.rb
+++ b/lib/mongoid/locker.rb
@@ -140,7 +140,7 @@ module Mongoid
             { locking_name_field => { '$exists': true, '$ne': nil } },
             { locked_at_field => { '$exists': true, '$ne': nil } },
             {
-              # Compare locked_at to current date in seconds plus lockout time
+              # Compare locked_at to current date minus the lockout time
               locked_at_field => { '$gte': Time.now - lock_timeout }
               # Replaces JS:
               # '$where': "new Date() - this.#{locked_at_field} < #{lock_timeout * 1000}"
@@ -174,7 +174,7 @@ module Mongoid
               ]
             },
             {
-              # Compare locked_at to current date in seconds plus lockout time
+              # Compare locked_at to current date minus the lockout time
               locked_at_field => { '$lt': Time.now - lock_timeout }
               # Replaces JS:
               # '$where': "new Date() - this.#{locked_at_field} >= #{lock_timeout * 1000}"

--- a/lib/mongoid/locker.rb
+++ b/lib/mongoid/locker.rb
@@ -141,7 +141,7 @@ module Mongoid
             { locked_at_field => { '$exists': true, '$ne': nil } },
             { 
               # Compare locked_at to current date in seconds plus lockout time
-              model.locked_at_field => { '$lt': DateTime.now.to_i + model.lock_timeout }
+              model.locked_at_field => { '$lt': DateTime.now.to_i - model.lock_timeout }
               # Replaces JS: '$where': "new Date() - this.#{locked_at_field} < #{lock_timeout * 1000}"  
             }
           ]
@@ -174,7 +174,7 @@ module Mongoid
             },
             {
               # Compare locked_at to current date in seconds plus lockout time
-              model.locked_at_field => { '$gte': DateTime.now.to_i + model.lock_timeout }
+              model.locked_at_field => { '$gte': DateTime.now.to_i - model.lock_timeout }
               # Replaces JS: '$where': "new Date() - this.#{locked_at_field} >= #{lock_timeout * 1000}"
             }
           ]

--- a/lib/mongoid/locker.rb
+++ b/lib/mongoid/locker.rb
@@ -141,7 +141,7 @@ module Mongoid
             { locked_at_field => { '$exists': true, '$ne': nil } },
             {
               # Compare locked_at to current date in seconds plus lockout time
-              locked_at_field => { '$gte': Time.now - lock_timeout.seconds }
+              locked_at_field => { '$gte': Time.now - lock_timeout }
               # Replaces JS:
               # '$where': "new Date() - this.#{locked_at_field} < #{lock_timeout * 1000}"
             }
@@ -175,7 +175,7 @@ module Mongoid
             },
             {
               # Compare locked_at to current date in seconds plus lockout time
-              locked_at_field => { '$lt': Time.now - lock_timeout.seconds }
+              locked_at_field => { '$lt': Time.now - lock_timeout }
               # Replaces JS:
               # '$where': "new Date() - this.#{locked_at_field} >= #{lock_timeout * 1000}"
             }

--- a/lib/mongoid/locker/wrapper.rb
+++ b/lib/mongoid/locker/wrapper.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'date'
 
 module Mongoid
   module Locker

--- a/lib/mongoid/locker/wrapper.rb
+++ b/lib/mongoid/locker/wrapper.rb
@@ -36,7 +36,7 @@ module Mongoid
               ]
             },
             {
-              # Compare locked_at to current date in seconds plus lockout time
+              # Compare locked_at to current date minus the lockout time
               model.locked_at_field => { '$lt': Time.now - model.lock_timeout }
               # Replaces JS:
               # '$where': "new Date() - this.#{model.locked_at_field} >= #{model.lock_timeout * 1000}"

--- a/lib/mongoid/locker/wrapper.rb
+++ b/lib/mongoid/locker/wrapper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'date'
 
 module Mongoid
   module Locker
@@ -37,8 +38,9 @@ module Mongoid
             },
             {
               # Compare locked_at to current date in seconds plus lockout time
-              model.locked_at_field => { '$gte': DateTime.now.to_i - model.lock_timeout }
-              # Replaces JS: '$where': "new Date() - this.#{model.locked_at_field} >= #{model.lock_timeout * 1000}"
+              model.locked_at_field => { '$lt': Time.now - model.lock_timeout.seconds }
+              # Replaces JS:
+              # '$where': "new Date() - this.#{model.locked_at_field} >= #{model.lock_timeout * 1000}"
             }
           ]
         }

--- a/lib/mongoid/locker/wrapper.rb
+++ b/lib/mongoid/locker/wrapper.rb
@@ -37,7 +37,7 @@ module Mongoid
             },
             {
               # Compare locked_at to current date in seconds plus lockout time
-              model.locked_at_field => { '$lt': Time.now - model.lock_timeout.seconds }
+              model.locked_at_field => { '$lt': Time.now - model.lock_timeout }
               # Replaces JS:
               # '$where': "new Date() - this.#{model.locked_at_field} >= #{model.lock_timeout * 1000}"
             }

--- a/lib/mongoid/locker/wrapper.rb
+++ b/lib/mongoid/locker/wrapper.rb
@@ -36,7 +36,9 @@ module Mongoid
               ]
             },
             {
-              '$where': "new Date() - this.#{model.locked_at_field} >= #{model.lock_timeout * 1000}"
+              # Compare locked_at to current date in seconds plus lockout time
+              model.locked_at_field => { '$gte': DateTime.now.to_i + model.lock_timeout }
+              # Replaces JS: '$where': "new Date() - this.#{model.locked_at_field} >= #{model.lock_timeout * 1000}"
             }
           ]
         }

--- a/lib/mongoid/locker/wrapper.rb
+++ b/lib/mongoid/locker/wrapper.rb
@@ -37,7 +37,7 @@ module Mongoid
             },
             {
               # Compare locked_at to current date in seconds plus lockout time
-              model.locked_at_field => { '$gte': DateTime.now.to_i + model.lock_timeout }
+              model.locked_at_field => { '$gte': DateTime.now.to_i - model.lock_timeout }
               # Replaces JS: '$where': "new Date() - this.#{model.locked_at_field} >= #{model.lock_timeout * 1000}"
             }
           ]

--- a/spec/test_examples_spec.rb
+++ b/spec/test_examples_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Test examples' do
 
       expect do
         CustomerService.new(customer).add_amount!(7)
-      end.not_to change(customer.reload.amount)
+      end.not_to change{customer.reload.amount}
     end
 
     it 'does not add amount to customer 2' do
@@ -69,7 +69,7 @@ RSpec.describe 'Test examples' do
 
       expect do
         CustomerService.new(customer).add_amount!(7)
-      end.not_to change(customer.reload.amount)
+      end.not_to change{customer.reload.amount}
     end
   end
 end

--- a/spec/test_examples_spec.rb
+++ b/spec/test_examples_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Test examples' do
 
       expect do
         CustomerService.new(customer).add_amount!(7)
-      end.not_to change{customer.reload.amount}
+      end.not_to(change { customer.reload.amount })
     end
 
     it 'does not add amount to customer 2' do
@@ -69,7 +69,7 @@ RSpec.describe 'Test examples' do
 
       expect do
         CustomerService.new(customer).add_amount!(7)
-      end.not_to change{customer.reload.amount}
+      end.not_to(change { customer.reload.amount })
     end
   end
 end


### PR DESCRIPTION
Replace Javascript filters with standard operators for use where Javascript is disabled on the MongoDB instance.